### PR TITLE
🔧 Add :astro preset to Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,7 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
-	"extends": ["github>derteaser/renovate-presets", "github>derteaser/renovate-presets:astro"]
+	"extends": [
+		"github>derteaser/renovate-presets",
+		"github>derteaser/renovate-presets:astro"
+	]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,4 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
-	"extends": ["github>derteaser/renovate-presets"]
+	"extends": ["github>derteaser/renovate-presets", "github>derteaser/renovate-presets:astro"]
 }


### PR DESCRIPTION
## Summary

Adds the `:astro` preset from [derteaser/renovate-presets](https://github.com/derteaser/renovate-presets) on top of the existing universal baseline.

## Why

`:astro` groups `@astro-community/*` plugins (core `astro` + `@astrojs/*` are already covered by Renovate's built-in `monorepo:astro`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)