### PR TITLE
✨ Add custom 404 page

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -12,9 +12,10 @@ import Hero from "../components/Hero.astro";
 
 export interface Props {
 	title: string;
+	hero?: boolean;
 }
 
-const { title } = Astro.props as Props;
+const { title, hero = true } = Astro.props as Props;
 const currentDate = new Date();
 ---
 
@@ -32,7 +33,7 @@ const currentDate = new Date();
 		<title>{title}</title>
 	</head>
 	<body>
-		<Hero />
+		{hero && <Hero />}
 		<slot />
 		<footer class="text-sm text-cream/60 my-20 px-12 text-center">
 			&copy;{currentDate.getFullYear()} Nüsser Nachtschwärmer<br />

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,0 +1,44 @@
+---
+import Layout from "../layouts/Layout.astro";
+---
+
+<Layout title="404 – Seite nicht gefunden" hero={false}>
+	<main
+		class="min-h-screen flex items-center justify-center px-6 py-20 text-center"
+	>
+		<div class="container mx-auto max-w-xl flex flex-col items-center gap-6">
+			<svg
+				xmlns="http://www.w3.org/2000/svg"
+				viewBox="0 0 64 64"
+				class="size-16 text-gold"
+				aria-hidden="true"
+			>
+				<path
+					fill="currentColor"
+					d="M41.5 44.2A20 20 0 1 1 19.8 22.5 16 16 0 0 0 41.5 44.2Z"></path>
+			</svg>
+
+			<p class="uppercase text-xs tracking-[0.28em] text-gold-muted font-title">
+				Fehler 404
+			</p>
+
+			<h1
+				class="font-title uppercase text-3xl sm:text-4xl tracking-wider text-gold leading-tight text-balance"
+			>
+				Im Dunkeln verlaufen?
+			</h1>
+
+			<p class="text-cream/80 text-lg leading-relaxed text-balance">
+				Diese Seite hat sich in der Nacht verirrt. Vielleicht gab es sie nie,
+				vielleicht ist sie längst weitergezogen.
+			</p>
+
+			<a
+				href="/"
+				class="mt-4 inline-block font-title uppercase text-sm tracking-[0.2em] text-gold border-b border-gold pb-1 hover:text-cream hover:border-cream transition-colors"
+			>
+				Zurück zur Startseite
+			</a>
+		</div>
+	</main>
+</Layout>


### PR DESCRIPTION
## Summary

- Adds [src/pages/404.astro](src/pages/404.astro) — a themed German "Im Dunkeln verlaufen?" page so unknown routes land on something on-brand instead of Astro's generic fallback ([docs](https://docs.astro.build/en/basics/astro-pages/#custom-404-error-page)).
- Makes `<Hero />` optional in [src/layouts/Layout.astro](src/layouts/Layout.astro) via a new `hero?: boolean` prop (default `true`). The 404 opts out so users don't have to scroll past a full-viewport splash animation to read the error message. `index.astro` is unchanged.

The 404 reuses existing design tokens (`text-gold`, `font-title`, `text-cream`, etc.) — no new CSS, no new dependencies.

## Test plan

- [x] `pnpm dev` → visit `http://localhost:4321/this-route-does-not-exist` and confirm: no Hero splash, gold heading, link back to `/` works, footer still renders.
- [x] Click "Zurück zur Startseite" and confirm the home page Hero animation still plays.
- [x] `pnpm build` produces `dist/404.html`.
- [x] `pnpm lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)